### PR TITLE
【Documents】LICENSEの追加

### DIFF
--- a/Assets/YukimaruGames/Terminal/LICENSE
+++ b/Assets/YukimaruGames/Terminal/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 YuukiReiya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
# Overview

下図のLICENSE部分のアクティベートを目的。

<img width="827" height="507" alt="CHANGELOG" src="https://github.com/user-attachments/assets/26541f63-4248-427d-8a59-e30411a985c8" />

* #7
上記PRにおけるLICENSE部分の対応。