### PR TITLE
【Bugfix】KeyboardType「LegacyInput」利用時に例外が発生する問題の修正

### DIFF
--- a/Assets/YukimaruGames/Terminal/Runtime/Bootstrapper/Editor/TerminalBootstrapper.editor.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/Bootstrapper/Editor/TerminalBootstrapper.editor.cs
@@ -404,6 +404,7 @@ namespace YukimaruGames.Terminal.Editor
             var prevHistoryKeyProp = _legacyInputKeyProp.FindPropertyRelative("_prevHistoryKeyCode");
             var nextHistoryKeyProp = _legacyInputKeyProp.FindPropertyRelative("_nextHistoryKeyCode");
             var autocompleteKeyProp = _legacyInputKeyProp.FindPropertyRelative("_autocompleteKeyCode");
+            var focusKeyProp = _legacyInputKeyProp.FindPropertyRelative("_focusKeyCode");
 
             EditorGUILayout.PropertyField(openKeyProp, new GUIContent(OpenKeyName));
             EditorGUILayout.PropertyField(closeKeyProp, new GUIContent(CloseKeyName));
@@ -411,6 +412,7 @@ namespace YukimaruGames.Terminal.Editor
             EditorGUILayout.PropertyField(prevHistoryKeyProp, new GUIContent(PrevHistoryKeyName));
             EditorGUILayout.PropertyField(nextHistoryKeyProp, new GUIContent(NextHistoryKeyName));
             EditorGUILayout.PropertyField(autocompleteKeyProp, new GUIContent(AutocompleteKeyName));
+            EditorGUILayout.PropertyField(focusKeyProp, new GUIContent(FocusKeyName));
         }
     }
 }

--- a/Assets/YukimaruGames/Terminal/Runtime/Bootstrapper/Editor/YukimaruGames.Terminal.Editor.asmdef
+++ b/Assets/YukimaruGames/Terminal/Runtime/Bootstrapper/Editor/YukimaruGames.Terminal.Editor.asmdef
@@ -5,7 +5,9 @@
         "GUID:ff00dc9bec88d6840a6862f796286f47",
         "GUID:e219bb3678c74bd4bab8e224eb77b2ad"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Assets/YukimaruGames/Terminal/Runtime/Input/LegacyInput/LegacyInputKey.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/Input/LegacyInput/LegacyInputKey.cs
@@ -20,6 +20,7 @@ namespace YukimaruGames.Terminal.Runtime.Input.LegacyInput
         [SerializeField] private KeyCode _prevHistoryKeyCode = KeyCode.UpArrow;
         [SerializeField] private KeyCode _nextHistoryKeyCode = KeyCode.DownArrow;
         [SerializeField] private KeyCode _autocompleteKeyCode = KeyCode.Tab;
+        [SerializeField] private KeyCode _focusKeyCode = KeyCode.LeftControl;
 
         public KeyCode GetKey(TerminalAction action) => action switch
         {
@@ -30,7 +31,7 @@ namespace YukimaruGames.Terminal.Runtime.Input.LegacyInput
             TerminalAction.PreviousHistory => _prevHistoryKeyCode,
             TerminalAction.NextHistory => _nextHistoryKeyCode,
             TerminalAction.Autocomplete => _autocompleteKeyCode,
-            TerminalAction.Focus => KeyCode.None,
+            TerminalAction.Focus => _focusKeyCode,
             _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
         };
     }

--- a/Assets/YukimaruGames/Terminal/Runtime/Input/LegacyInput/LegacyInputKey.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/Input/LegacyInput/LegacyInputKey.cs
@@ -30,6 +30,7 @@ namespace YukimaruGames.Terminal.Runtime.Input.LegacyInput
             TerminalAction.PreviousHistory => _prevHistoryKeyCode,
             TerminalAction.NextHistory => _nextHistoryKeyCode,
             TerminalAction.Autocomplete => _autocompleteKeyCode,
+            TerminalAction.Focus => KeyCode.None,
             _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
         };
     }


### PR DESCRIPTION
# Problem

KeyboardTypeに`LegacyInput`を指定した際に起動時に例外が送出されてしまう。

```rb
ArgumentOutOfRangeException: Exception of type 'System.ArgumentOutOfRangeException' was thrown.
Parameter name: action
Actual value was Focus.
YukimaruGames.Terminal.Runtime.Input.LegacyInput.LegacyInputKey.GetKey (YukimaruGames.Terminal.UI.View.Model.TerminalAction action) (at Assets/YukimaruGames/Terminal/Runtime/Input/LegacyInput/LegacyInputKey.cs:34)
```

# Cause

`InputSystem`向けに入力フィールドにフォーカスするショートカットアクションを追加した。
`LegacyInput`には機能的に不要だと判断し追加していなかったが例外送出されるのと、有効なアクションであったため機能として追加する。

# Solution

- [x] Editor拡張用のAssemblyDefinition(「YukimaruGames.Terminal.Editor」)がPlatform「Any」に設定されていたため「Editor」に変更。
- [x] KeyboardTypeの動的な変更及び`LegacyInput`のキーコードを動的に変更した際に変更が反映されることの確認。
- [x] 例外が発生しないことを確認。
