### PR TITLE
【Bugfix】Tabキーの押下で入力フィールドからフォーカスがログに移ってしまう問題の暫定対応

### DIFF
--- a/Assets/YukimaruGames/Terminal/CHANGELOG.md
+++ b/Assets/YukimaruGames/Terminal/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+---
+
+# Known Issues
+- **Input Field Focus Issue:**
+When `KeyboardType` is set to `InputSystem`, pressing the Tab key temporarily shifts the focus from the input field to the log text.
+This issue is tracked in Issue [#16](https://github.com/YuukiReiya/YukimaruGames.Unity-Terminal/issues/16).
+We'll proceed with using a `Label` for the log display as our primary approach for now, but may pivot to a better solution in the future.
+
+---
+
 ## [1.0.0] - yyyy-MM-DD
 
 ### Changed

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/View/Renderer/TerminalLogRenderer.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/View/Renderer/TerminalLogRenderer.cs
@@ -51,7 +51,8 @@ namespace YukimaruGames.Terminal.UI.View
                 OnPreRender?.Invoke(logEntry);
 
                 _styleProvider.SetColor(GetColor(logEntry.MessageType));
-                GUILayout.TextField(logEntry.Message, _styleProvider.GetStyle());
+                // TODO:コピペ可能な選択フィールドの実装が理想.
+                GUILayout.Label(logEntry.Message, _styleProvider.GetStyle());
                 
                 OnPostRender?.Invoke(logEntry);
             }


### PR DESCRIPTION
# Overview

* #16

入力フィールドに対してフォーカスがあたっている際にTabキーが押下されると一時的にログにフォーカスがあたってしまう問題。

上記の不具合に対しての暫定的な対応。

# Solution

Issueで触れているように`TextField`を`Label`に変更する方針で対応。