### PR TITLE
【Refactor】メモリリークの疑いのある実装に対して明示的Disposeを呼ぶように

### DIFF
--- a/Assets/YukimaruGames/Terminal/Runtime/Infrastructure/Context/TerminalGUIStyleContext.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/Infrastructure/Context/TerminalGUIStyleContext.cs
@@ -60,7 +60,7 @@ namespace YukimaruGames.Terminal.Infrastructure
 
         private void HandleFontSizeChanged(int size) => _styleLazy.Value.fontSize = size;
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             OnStyleChanged = null;
             if (_provider != null)

--- a/Assets/YukimaruGames/Terminal/Runtime/Infrastructure/Provider/TerminalFontProvider.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/Infrastructure/Provider/TerminalFontProvider.cs
@@ -84,7 +84,7 @@ namespace YukimaruGames.Terminal.Infrastructure
             }
         }
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             Clear();
             _onFontChanged = null;

--- a/Assets/YukimaruGames/Terminal/Runtime/Infrastructure/Repository/PixelTexture2DRepository.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/Infrastructure/Repository/PixelTexture2DRepository.cs
@@ -21,10 +21,17 @@ namespace YukimaruGames.Terminal.Infrastructure
 
         public void SetColor(string key, in Color color)
         {
-            _dic.GetValueOrDefault(key)?.SetColor(color);
+            if (_dic.TryGetValue(key,out var handle))
+            {
+                handle.SetColor(color);
+            }
+            else
+            {
+                _dic.Add(key, new PixelTexture2DHandle(color));
+            }
         }
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             foreach (var kvp in _dic)
             {

--- a/Assets/YukimaruGames/Terminal/Runtime/Runtime/Bootstrapper/TerminalBootstrapper.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/Runtime/Bootstrapper/TerminalBootstrapper.cs
@@ -14,6 +14,7 @@ using YukimaruGames.Terminal.Runtime.Input.LegacyInput;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using UnityEngine;
 using YukimaruGames.Terminal.Application;
 using YukimaruGames.Terminal.Domain.Interface;
@@ -77,6 +78,7 @@ namespace YukimaruGames.Terminal.Runtime
         [SerializeField] private bool _buttonReverse;
         
         private readonly List<IUpdatable> _updatables = new();
+        private readonly List<IDisposable> _disposables = new();
 
         private InputKeyboardType KeyboardType =>
 #if ENABLE_LEGACY_INPUT_MANAGER && ENABLE_INPUT_SYSTEM
@@ -160,14 +162,17 @@ namespace YukimaruGames.Terminal.Runtime
 
             var scrollConfigurator = new ScrollConfigurator();
             _registry = new CommandRegistry(_logger);
+            var invoker = new CommandInvoker();
+            var parser = new CommandParser();
+            var history = new CommandHistory();
             var discover = new CommandDiscoverer(_logger);
             _autocomplete = new CommandAutocomplete(); 
             _service = new TerminalService(
                 _logger,
                 _registry,
-                new CommandInvoker(),
-                new CommandParser(),
-                new CommandHistory(),
+                invoker,
+                parser,
+                history,
                 _autocomplete);
 
             var specs = discover.Discover();
@@ -248,7 +253,62 @@ namespace YukimaruGames.Terminal.Runtime
                 _executeButtonPresenter,
                 _buttonPresenter,
                 _eventListener);
-            _updatables.Add(_eventListener);
+            
+            var instances = new object[]
+            {
+                scrollConfigurator,
+                factory,
+
+                // domain
+                _service,
+                _logger,
+                invoker,
+                parser,
+                history,
+                discover,
+                _registry,
+                _autocomplete,
+                
+                // provider.
+                _animatorDataConfigurator,
+                _colorPaletteProvider,
+                _fontProvider,
+                _pixelTexture2DRepository,
+                
+                // listener.
+                _eventListener,
+                
+                // context.
+                _logStyleContext,
+                _inputStyleContext,
+                _promptStyleContext,
+                _executeButtonsStyleContext,
+                _openButtonsStyleContext,
+                _logCopyButtonStyleContext,
+                
+                _cursorFlashSpeedProvider,
+                _buttonVisibleConfigurator,
+                
+                // renderer.
+                _windowRenderer,
+                _logCopyButtonRenderer,
+                _logRenderer,
+                _inputRenderer,
+                _promptRenderer,
+                _executeButtonRenderer,
+                _buttonRenderer,
+                _view,
+                
+                // presenter.
+                _windowPresenter,
+                _logPresenter,
+                _inputPresenter,
+                _executeButtonPresenter,
+                _buttonPresenter,
+                _coordinator,
+            };
+            _updatables.AddRange(instances.OfType<IUpdatable>());
+            _disposables.AddRange(instances.OfType<IDisposable>());
             Configure();
         }
 
@@ -274,7 +334,10 @@ namespace YukimaruGames.Terminal.Runtime
 
         private void OnDestroy()
         {
-            Dispose();
+            if (this is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
         }
 
         [Conditional("UNITY_EDITOR")]
@@ -351,21 +414,14 @@ namespace YukimaruGames.Terminal.Runtime
             return factory.Create(KeyboardType);
         }
         
-        public void Dispose()
+        void IDisposable.Dispose()
         {
-            (_view as IDisposable)?.Dispose();
-            _coordinator?.Dispose();
-            _fontProvider?.Dispose();
-            _logStyleContext?.Dispose();
-            _inputStyleContext?.Dispose();
-            _logRenderer?.Dispose();
-            _logCopyButtonRenderer?.Dispose();
-            _promptRenderer?.Dispose();
-            _windowPresenter?.Dispose();
-            _logPresenter?.Dispose();
-            _inputPresenter?.Dispose();
-            _executeButtonPresenter?.Dispose();
-            _buttonPresenter?.Dispose();
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (var i = 0; i < _disposables.Count; i++)
+            {
+                _disposables[i]?.Dispose();
+            }
+            _disposables.Clear();
         }
     }
 }

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Coordinator/TerminalCoordinator.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Coordinator/TerminalCoordinator.cs
@@ -179,7 +179,7 @@ namespace YukimaruGames.Terminal.UI.Presentation
             GUIUtility.systemCopyBuffer = copiedText;
         }
         
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             UnregisterEvents();
         }

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalButtonPresenter.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalButtonPresenter.cs
@@ -4,7 +4,7 @@ using YukimaruGames.Terminal.UI.View;
 
 namespace YukimaruGames.Terminal.UI.Presentation
 {
-    public sealed class TerminalButtonPresenter : ITerminalButtonPresenter, ITerminalButtonRenderDataProvider,IDisposable
+    public sealed class TerminalButtonPresenter : ITerminalButtonPresenter, ITerminalButtonRenderDataProvider, IDisposable
     {
         private readonly ITerminalButtonRenderer _renderer;
         private readonly ITerminalWindowPresenter _windowPresenter;
@@ -12,8 +12,8 @@ namespace YukimaruGames.Terminal.UI.Presentation
 
         public event Action OnOpenTriggered;
         public event Action OnCloseTriggered;
-        
-        public TerminalButtonPresenter(ITerminalButtonRenderer renderer,ITerminalWindowPresenter windowPresenter, ITerminalButtonVisibleProvider buttonVisibleProvider)
+
+        public TerminalButtonPresenter(ITerminalButtonRenderer renderer, ITerminalWindowPresenter windowPresenter, ITerminalButtonVisibleProvider buttonVisibleProvider)
         {
             _renderer = renderer;
             _windowPresenter = windowPresenter;
@@ -23,7 +23,7 @@ namespace YukimaruGames.Terminal.UI.Presentation
             _renderer.OnClickCloseButton += HandleClickCloseButton;
         }
 
-        public TerminalButtonRenderData GetRenderData()
+        TerminalButtonRenderData ITerminalButtonRenderDataProvider.GetRenderData()
         {
             return new TerminalButtonRenderData(_buttonVisibleProvider.IsVisible, _buttonVisibleProvider.IsReverse, _windowPresenter.Rect, _windowPresenter.Anchor);
         }
@@ -31,11 +31,11 @@ namespace YukimaruGames.Terminal.UI.Presentation
         private void HandleClickOpenButton() => OnOpenTriggered?.Invoke();
         private void HandleClickCloseButton() => OnCloseTriggered?.Invoke();
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             _renderer.OnClickOpenButton -= HandleClickOpenButton;
             _renderer.OnClickCloseButton -= HandleClickCloseButton;
-            
+
             OnOpenTriggered = null;
             OnCloseTriggered = null;
         }

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalExecuteButtonPresenter.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalExecuteButtonPresenter.cs
@@ -4,32 +4,32 @@ using YukimaruGames.Terminal.UI.View;
 
 namespace YukimaruGames.Terminal.UI.Presentation
 {
-    public sealed class TerminalExecuteButtonPresenter : ITerminalExecuteButtonPresenter,IDisposable
+    public sealed class TerminalExecuteButtonPresenter : ITerminalExecuteButtonPresenter, IDisposable
     {
         private readonly ITerminalExecuteButtonRenderer _renderer;
         private readonly ITerminalButtonVisibleProvider _buttonVisibleProvider;
-        
+
         public event Action OnExecuteTriggered;
-        
-        public TerminalExecuteButtonPresenter(ITerminalExecuteButtonRenderer renderer,ITerminalButtonVisibleProvider buttonVisibleProvider)
+
+        public TerminalExecuteButtonPresenter(ITerminalExecuteButtonRenderer renderer, ITerminalButtonVisibleProvider buttonVisibleProvider)
         {
             _renderer = renderer;
             _buttonVisibleProvider = buttonVisibleProvider;
 
             _renderer.OnClickButton += HandleClickExecuteButton;
         }
-        
-        public TerminalExecuteButtonRenderData GetRenderData()
+
+        TerminalExecuteButtonRenderData ITerminalExecuteButtonRenderDataProvider.GetRenderData()
         {
             return new TerminalExecuteButtonRenderData(_buttonVisibleProvider.IsVisible);
         }
 
         private void HandleClickExecuteButton() => OnExecuteTriggered?.Invoke();
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             _renderer.OnClickButton -= HandleClickExecuteButton;
-            
+
             OnExecuteTriggered = null;
         }
     }

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalInputPresenter.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalInputPresenter.cs
@@ -38,7 +38,7 @@ namespace YukimaruGames.Terminal.UI.Presentation
 
         public void SetMoveCursorToEnd() => _isMoveCursorToEnd = true;
 
-        public TerminalInputRenderData GetRenderData()
+        TerminalInputRenderData ITerminalInputRenderDataProvider.GetRenderData()
         {
             return new TerminalInputRenderData(InputText, FocusControl, _isMoveCursorToEnd);
         }
@@ -65,7 +65,7 @@ namespace YukimaruGames.Terminal.UI.Presentation
             IsImeComposing = isImeComposing;
         }
         
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             if (_renderer != null)
             {

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalLogPresenter.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalLogPresenter.cs
@@ -42,7 +42,7 @@ namespace YukimaruGames.Terminal.UI.Presentation.Model
         /// </remarks>
         TerminalLogRenderData ITerminalLogRenderDataProvider.GetRenderData() => _cachedLogRenderData;
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             _service.OnLogUpdated -= HandleLogUpdated;
             _service.OnLogAdded -= HandleLogAdded;

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalWindowPresenter.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/Presentation/Presenter/TerminalWindowPresenter.cs
@@ -150,12 +150,12 @@ namespace YukimaruGames.Terminal.UI.Presentation
                 State, Anchor, Style, duration, Scale, elapsed);
         }
 
-        public TerminalWindowRenderData GetRenderData()
+        TerminalWindowRenderData ITerminalWindowRenderDataProvider.GetRenderData()
         {
             return new TerminalWindowRenderData(GetHashCode(), Rect);
         }
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             _onCompleted = null;
             _onAborted = null;

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/View/Interface/IPixelTexture2DRepository.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/View/Interface/IPixelTexture2DRepository.cs
@@ -4,7 +4,6 @@ namespace YukimaruGames.Terminal.UI.View
 {
     public interface IPixelTexture2DRepository
     {
-        void Add(string key, Color color);
         Texture2D GetTexture2D(string key);
         void SetColor(string key, in Color color);
     }

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/View/Orchestrator/TerminalView.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/View/Orchestrator/TerminalView.cs
@@ -68,8 +68,8 @@ namespace YukimaruGames.Terminal.UI.View
             _scrollConfigurator = scrollConfigurator;
 
             _logCopyButtonRenderer.OnClickButton += HandleLogCopied;
-            
-            _preRenderers = new object[]
+
+            var renderers = new object[]
             {
                 _windowRenderer,
                 _logRenderer,
@@ -77,18 +77,12 @@ namespace YukimaruGames.Terminal.UI.View
                 _promptRenderer,
                 _executeButtonRenderer,
                 _buttonRenderer,
-            }.OfType<ITerminalPreRenderer>().ToList();
+            };
+
+            _preRenderers = new List<ITerminalPreRenderer>(renderers.OfType<ITerminalPreRenderer>());
             OnPreRender += ExecutePreRender;
 
-            _postRenderers = new object[]
-            {
-                _windowRenderer,
-                _logRenderer,
-                _inputRenderer,
-                _promptRenderer,
-                _executeButtonRenderer,
-                _buttonRenderer,
-            }.OfType<ITerminalPostRenderer>().ToList();
+            _postRenderers = new List<ITerminalPostRenderer>(renderers.OfType<ITerminalPostRenderer>());
             OnPostRender += ExecutePostRender;
         }
 
@@ -149,12 +143,15 @@ namespace YukimaruGames.Terminal.UI.View
             OnLogCopiedTriggered?.Invoke(copiedText);
         }
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             _logCopyButtonRenderer.OnClickButton -= HandleLogCopied;
             
             OnPreRender -= ExecutePreRender;
             OnPostRender -= ExecutePostRender;
+            
+            _preRenderers.Clear();
+            _postRenderers.Clear();
             
             OnScreenSizeChanged = null;
             OnLogCopiedTriggered = null;

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/View/Renderer/TerminalLogRenderer.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/View/Renderer/TerminalLogRenderer.cs
@@ -17,7 +17,7 @@ namespace YukimaruGames.Terminal.UI.View
         public event Action<LogRenderData> OnPreRender;
         public event Action<LogRenderData> OnPostRender;
 
-        public TerminalLogRenderer(ITerminalLogCopyButtonRenderer logCopyButtonRenderer,IGUIStyleProvider styleProvider, IColorPaletteProvider colorPaletteProvider)
+        public TerminalLogRenderer(ITerminalLogCopyButtonRenderer logCopyButtonRenderer, IGUIStyleProvider styleProvider, IColorPaletteProvider colorPaletteProvider)
         {
             _copyButtonRenderer = logCopyButtonRenderer;
             _styleProvider = styleProvider;
@@ -56,7 +56,7 @@ namespace YukimaruGames.Terminal.UI.View
                 // TODO:コピペ可能な選択フィールドの実装が理想.
                 GUILayout.Label(renderData.Message, _styleProvider.GetStyle());
                 if (ShouldDrawCopyButton(renderData)) _copyButtonRenderer.Render(renderData.Message);
-                
+
                 OnPostRender?.Invoke(renderData);
             }
 
@@ -69,12 +69,12 @@ namespace YukimaruGames.Terminal.UI.View
             {
                 return false;
             }
-            
+
             return renderData.MessageType switch
             {
                 MessageType.System => false,
                 _ => true,
-            };   
+            };
         }
     }
 }

--- a/Assets/YukimaruGames/Terminal/Runtime/UI/View/Renderer/TerminalWindowRenderer.cs
+++ b/Assets/YukimaruGames/Terminal/Runtime/UI/View/Renderer/TerminalWindowRenderer.cs
@@ -15,7 +15,7 @@ namespace YukimaruGames.Terminal.UI.View
         public TerminalWindowRenderer(IPixelTexture2DRepository pixelTextureRepository)
         {
             _textureRepository = pixelTextureRepository;
-            _textureRepository.Add(Key, Color.black);
+            _textureRepository.SetColor(Key, Color.black);
 
             _styleLazy = new Lazy<GUIStyle>(new GUIStyle()
             {


### PR DESCRIPTION
# Overview

```cs
            _service = new TerminalService(
                _logger,
                _registry,
                new CommandInvoker(),
                new CommandParser(),
                new CommandHistory(),
                _autocomplete);
```

ここで`new`しているオブジェクトが`event`を持っており、メモリリークしてしまう懸念がある。
そのため明示的にDisposeを行うことで解放漏れを防止。